### PR TITLE
Import Webradio title from .pls file

### DIFF
--- a/webradio/README.md
+++ b/webradio/README.md
@@ -9,3 +9,4 @@ Title1=Pretty Name
 ```
 
 If `Title` is defined inside the `.pls` file that value will be used, else we fall back to `filename`
+

--- a/webradio/README.md
+++ b/webradio/README.md
@@ -1,10 +1,11 @@
-Webradio import
----
+### Webradio import
 
-For importing webradio in format of:
+To import Webradios, you can create a file `<radioname>.pls` and save it in `/mnt/MPD/Webradio`, using the following format
 ```sh
 [playlist]
 NumberOfEntries=1
 File1=http://url/path
-Title1=filename
+Title1=Pretty Name
 ```
+
+If `Title` is defined inside the `.pls` file that value will be used, else we fall back to `filename`

--- a/webradio/importwebradio.sh
+++ b/webradio/importwebradio.sh
@@ -21,10 +21,11 @@ for file in "${files[@]}"; do
 	name=$( basename "$file" .pls )
 	url=$( grep '^File' "$file" | cut -d '=' -f2- )
 	title=$( grep '^Title' "$file" | cut -d '=' -f2-)
-	printf "%-30s : $url\n" "$title ($name)"
-	if [! -z $title ]; then
-		echo $title> /srv/http/data/webradios/${url//\//|}
+	if [ ! -z "$title" ]; then
+		printf "%-30s : $url\n" "$title"
+		echo $title > /srv/http/data/webradios/${url//\//|}
 	else
+		printf "%-30s : $url\n" "$name"
 		echo $name > /srv/http/data/webradios/${url//\//|}
 	fi
 done

--- a/webradio/importwebradio.sh
+++ b/webradio/importwebradio.sh
@@ -20,8 +20,13 @@ readarray -t files <<<"$files"
 for file in "${files[@]}"; do
 	name=$( basename "$file" .pls )
 	url=$( grep '^File' "$file" | cut -d '=' -f2- )
-	printf "%-30s : $url\n" "$name"
-	echo $name > /srv/http/data/webradios/${url//\//|}
+	title=$( grep '^Title' "$file" | cut -d '=' -f2-)
+	printf "%-30s : $url\n" "$title ($name)"
+	if [! -z $title ]; then
+		echo $title> /srv/http/data/webradios/${url//\//|}
+	else
+		echo $name > /srv/http/data/webradios/${url//\//|}
+	fi
 done
 count=$( ls -1q /srv/http/data/webradios | wc -l )
 sed -i 's/\("webradio": \).*/\1'$count'/' /srv/http/data/mpd/counts


### PR DESCRIPTION
The patch greps the Title field from .pls file, if present that value will be used as name of the radio, else we fall back to filename.

That allows to have "normal" filenames for pls files, like all smallcase and no spaces and have a pretty name as the name of the radio